### PR TITLE
Register The AuthServiceProvider & Gate Facade

### DIFF
--- a/resources/stubs/config/app.php
+++ b/resources/stubs/config/app.php
@@ -141,6 +141,7 @@ return [
          * Application Service Providers...
          */
         App\Providers\AppServiceProvider::class,
+        App\Providers\AuthServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         Laravel\Cashier\CashierServiceProvider::class,
@@ -178,6 +179,7 @@ return [
         'Eloquent'  => Illuminate\Database\Eloquent\Model::class,
         'Event'     => Illuminate\Support\Facades\Event::class,
         'File'      => Illuminate\Support\Facades\File::class,
+        'Gate'      => Illuminate\Support\Facades\Gate::class,
         'Hash'      => Illuminate\Support\Facades\Hash::class,
         'Input'     => Illuminate\Support\Facades\Input::class,
         'Inspiring' => Illuminate\Foundation\Inspiring::class,


### PR DESCRIPTION
If spark is meant for fresh 5.1 installations, the Authorize service provider and Gate facade should be included.